### PR TITLE
Preprocessor definition to prevent delays.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ http://joanruedapauweb.com/blog/index.php/2017/02/07/arduino-serial-mp3-player-y
 
 (Chinese)(Catalex_YX5300_Docs.zip files)
 http://pan.baidu.com/s/1hqilpB2
+
+
+## A Note on Delays:
+
+To ensure the integrity of serial communication, this library implements a very conservative 20 ms delay before and 1000 ms delay after sending a command. More complicated sketches that can manage their own delays between serial commands can disable this delay with the preprocessor definition NO_SERIALMP3_DELAY.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SerialMP3Player
-version=1.0.0
+version=1.1.0
 author=Salvador Rueda <salvador.rueda@gmail.com>
 maintainer=Salvador Rueda <salvador.rueda@gmail.com>
 sentence=A library for Serial MP3 Player board (YX5300 chip).

--- a/src/SerialMP3Player.cpp
+++ b/src/SerialMP3Player.cpp
@@ -162,7 +162,10 @@ void SerialMP3Player::sendCommand(byte command, byte dat1, byte dat2){
 
   // Command Structure 0x7E 0xFF 0x06 CMD FBACK DAT1 DAT2 0xEF
 
+  #ifndef NO_SERIALMP3_DELAY
   delay(20);
+  #endif
+
   Send_buf[0] = 0x7E;    // Start byte
   Send_buf[1] = 0xFF;    // Version
   Send_buf[2] = 0x06;    // Command length not including Start and End byte.
@@ -182,7 +185,10 @@ void SerialMP3Player::sendCommand(byte command, byte dat1, byte dat2){
      Serial.println(mp3send); // watch what are we sending
   }
 
-  delay(1000);  // Wait between sending commands.
+  #ifndef NO_SERIALMP3_DELAY
+  delay(1000);
+  // Wait between sending commands.
+  #endif
 }
 
 //String sanswer(void);


### PR DESCRIPTION
This is a wonderful library, thank you for this work! I am using it in a project that also involves driving Neopixels, and the calls to the `delay` function after a serial communication in the `SerialMP3Player::sendCommand` function were interfering with updates to the Neopixel array. To allow a user to manage their own delays between calls, I've added preprocessor conditionals that will prevent the delays if the preprocessor value `NO_SERIALMP3_DELAY` is defined.

I've tested this change on an Arduino Uno running a Serial MP3 Player v1.0 and a set of 20 Neopixels. The library still works as expected when the preprocessor value is not defined. With the preprocessor definition, I achieve the desired behavior of serial commands being sent without delays. I was unable to elicit any erroneous serial communication despite rapidly sending serial commands to the mp3 unit (at roughly 5-10 Hz). I suspect the chip may be able to process commands fast enough to avoid a buffer overflow. Future versions of this library might consider making the delay less conservative or eradicating it altogether.