### PR TITLE
Fixed RX buffer to small

### DIFF
--- a/src/SerialMP3Player.h
+++ b/src/SerialMP3Player.h
@@ -101,7 +101,7 @@ class SerialMP3Player{
      String sbyte2hex(byte b);
      bool _showDebugMessages;
      SoftwareSerial *Serial3;
-     byte ansbuf[15] = {0}; // Buffer for the answers.
+     byte ansbuf[36] = {0}; // Buffer for the answers.
 
 };
 


### PR DESCRIPTION
Buffer is to small. When using command p to play something you will get a longer answer back from the module.  The previous small buffer will cause the MCU to reboot due to adressing a btye thats not allocated (Tested on ESP32 S2 Mini)